### PR TITLE
Add circular loaders to pages

### DIFF
--- a/src/features/reader/components/PageView.svelte
+++ b/src/features/reader/components/PageView.svelte
@@ -376,7 +376,7 @@
 
   {#key chapterEpoch}
     {#if style === "longstrip"}
-      {#each flatPages as page, gi}
+      {#each flatPages as page, gi (page.chapterId + ":" + page.localIndex)}
         {@const src = resolvedSrc[gi]}
         {@const isLoaded = loadedSet.has(gi)}
         <div
@@ -384,9 +384,9 @@
           use:observePage={gi}
           data-gi={gi}
         >
-          {#if isLoaded}
+          {#if isLoaded && src}
             <img
-              src={src ?? ""}
+              src={src}
               alt="{page.chapterName} – Page {page.localIndex + 1}"
               data-local-page={page.localIndex + 1}
               data-chapter={page.chapterId}
@@ -404,7 +404,9 @@
               }}
             />
           {:else}
-            <div class="strip-placeholder"></div>
+            <div class="strip-placeholder page-loader" aria-hidden="true">
+              <CircleNotch size={20} weight="light" class="anim-spin" style="color:var(--text-faint)" />
+            </div>
           {/if}
         </div>
       {/each}
@@ -413,7 +415,9 @@
     {:else if style === "fade" && pageReady}
       <div class="inspect-wrap" style="transform:scale({readerState.inspectScale}) translate({readerState.inspectPanX / readerState.inspectScale}px,{readerState.inspectPanY / readerState.inspectScale}px)">
         {#await resolveUrl(store.pageUrls[store.pageNumber - 1], 999)}
-          <img src="" alt="Page {store.pageNumber}" class={imgCls} decoding="async" style="opacity:0" draggable="false" />
+          <div class="page-loader page-loader-single" aria-hidden="true">
+            <CircleNotch size={20} weight="light" class="anim-spin" style="color:var(--text-faint)" />
+          </div>
         {:then src}
           <img {src} alt="Page {store.pageNumber}" class={imgCls} decoding="async" style="opacity: {fadingOut ? 0 : 1}; transition: opacity 0.1s ease;" draggable="false" />
         {/await}
@@ -423,9 +427,11 @@
       <div class="inspect-wrap" style="transform:scale({readerState.inspectScale}) translate({readerState.inspectPanX / readerState.inspectScale}px,{readerState.inspectPanY / readerState.inspectScale}px)">
         {#if pageGroups.length}
           <div class="double-wrap">
-            {#each currentGroup as pg, i}
+            {#each currentGroup as pg, i (pg)}
               {#await resolveUrl(store.pageUrls[pg - 1], 999)}
-                <img src="" alt="Page {pg}" class="{imgCls} page-half {i === 0 ? 'gap-left' : 'gap-right'}" decoding="async" draggable="false" />
+                <div class="page-loader page-half {i === 0 ? 'gap-left' : 'gap-right'}" aria-hidden="true">
+                  <CircleNotch size={20} weight="light" class="anim-spin" style="color:var(--text-faint)" />
+                </div>
               {:then src}
                 <img {src} alt="Page {pg}" class="{imgCls} page-half {i === 0 ? 'gap-left' : 'gap-right'}" decoding="async" draggable="false" />
               {/await}
@@ -439,7 +445,9 @@
     {:else if pageReady}
       <div class="inspect-wrap" style="transform:scale({readerState.inspectScale}) translate({readerState.inspectPanX / readerState.inspectScale}px,{readerState.inspectPanY / readerState.inspectScale}px)">
         {#await resolveUrl(store.pageUrls[store.pageNumber - 1], 999)}
-          <img src="" alt="Page {store.pageNumber}" class={imgCls} decoding="async" draggable="false" />
+          <div class="page-loader page-loader-single" aria-hidden="true">
+            <CircleNotch size={20} weight="light" class="anim-spin" style="color:var(--text-faint)" />
+          </div>
         {:then src}
           <img {src} alt="Page {store.pageNumber}" class={imgCls} decoding="async" draggable="false" />
         {/await}
@@ -471,7 +479,23 @@
     width: var(--effective-width, 100%);
     max-width: var(--effective-width, 100%);
     aspect-ratio: var(--aspect, 0.667);
-    background: transparent;
+    border-radius: var(--radius-sm);
+    background: color-mix(in srgb, var(--bg-raised) 90%, transparent);
+  }
+
+  .page-loader {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: color-mix(in srgb, var(--bg-raised) 90%, transparent);
+    border-radius: var(--radius-sm);
+  }
+
+  .page-loader-single {
+    width: min(100%, var(--effective-width, 100%));
+    max-width: var(--effective-width, 100%);
+    max-height: calc(100vh - 80px);
+    aspect-ratio: 2 / 3;
   }
 
   .img { display: block; user-select: none; image-rendering: auto; }


### PR DESCRIPTION
This is meant to be mainly the logic for doing per-page loaders. Unc said he would handle the UI cleanup side of things. 


### Copilot Generated Summary

This pull request enhances the user experience in the `PageView.svelte` component by improving how loading states are displayed for images in the reader. The main changes introduce animated loading indicators (spinners) in place of blank placeholders, and update the styling for loading containers to provide a more polished and consistent appearance.

**User experience improvements (loading indicators):**
- Replaced empty or blank placeholders with a spinner (`CircleNotch` icon) for loading images in all reading modes, including longstrip, fade, and double-page layouts. This provides clear visual feedback to users while images are loading. [[1]](diffhunk://#diff-66f5fb96a97ea9a99240e39f3ea5596eb9b14148dad3f0ebf8b01049c6dc424bL407-R409) [[2]](diffhunk://#diff-66f5fb96a97ea9a99240e39f3ea5596eb9b14148dad3f0ebf8b01049c6dc424bL416-R420) [[3]](diffhunk://#diff-66f5fb96a97ea9a99240e39f3ea5596eb9b14148dad3f0ebf8b01049c6dc424bL426-R434) [[4]](diffhunk://#diff-66f5fb96a97ea9a99240e39f3ea5596eb9b14148dad3f0ebf8b01049c6dc424bL442-R450)

**Rendering and performance:**
- Updated the `each` blocks in longstrip and double-page modes to use unique keys based on page identifiers, improving Svelte's rendering efficiency and reducing potential UI glitches. [[1]](diffhunk://#diff-66f5fb96a97ea9a99240e39f3ea5596eb9b14148dad3f0ebf8b01049c6dc424bL379-R389) [[2]](diffhunk://#diff-66f5fb96a97ea9a99240e39f3ea5596eb9b14148dad3f0ebf8b01049c6dc424bL426-R434)

**Styling and layout:**
- Added new CSS classes (`page-loader`, `page-loader-single`) to style the loading containers with proper centering, background, and border radius, ensuring the loaders fit seamlessly into the page layout and match the app's design language.


https://github.com/user-attachments/assets/63b1f4bd-4064-48e0-a6fd-b51892f0ac52